### PR TITLE
fixed fill tool not working on mobile

### DIFF
--- a/src/atrament.js
+++ b/src/atrament.js
@@ -342,9 +342,11 @@ class Atrament {
 
   _floodFill(startX, startY, startColor) {
     const context = this.context;
+    const startXf = Math.floor(startX);
+    const startYf = Math.floor(startY);
     const canvasWidth = context.canvas.width;
     const canvasHeight = context.canvas.height;
-    const pixelStack = [[Math.floor(startX), Math.floor(startY)]];
+    const pixelStack = [[startXf, startYf]];
     // hex needs to be trasformed to rgb since colorLayer accepts RGB
     const fillColor = Atrament.hexToRgb(this.color);
     // Need to save current context with colors, we will update it
@@ -355,7 +357,7 @@ class Atrament {
     const matchFillColor = Atrament.matchColor(colorLayer.data, ...[...fillColor, 255]);
 
     // check if we're trying to fill with the same colour, if so, stop
-    if (matchFillColor((startY * context.canvas.width + startX) * 4)) {
+    if (matchFillColor((startYf * context.canvas.width + startXf) * 4)) {
       this._filling = false;
       setTimeout(() => { this.canvas.style.cursor = 'crosshair'; }, 100);
       return;

--- a/src/atrament.js
+++ b/src/atrament.js
@@ -344,7 +344,7 @@ class Atrament {
     const context = this.context;
     const canvasWidth = context.canvas.width;
     const canvasHeight = context.canvas.height;
-    const pixelStack = [[startX, startY]];
+    const pixelStack = [[Math.floor(startX), Math.floor(startY)]];
     // hex needs to be trasformed to rgb since colorLayer accepts RGB
     const fillColor = Atrament.hexToRgb(this.color);
     // Need to save current context with colors, we will update it


### PR DESCRIPTION
closes #37 
When mouseX/mouseY have decimal digits, the algorithm miscalculates the starting position in which to apply the colorPixel function. This causes the colorData array to be misaligned. ie, filling the whole picture with (100,50,20,255) results in a color data array of [**255,100**,50,20,255,100,50,20...] instead of the correct [100,50,20,255,100,50,20,255...] which results in strange behaviors. 

Fixed the issue by flooring X and Y starting values, though there may be a better fix for the algorithm itself