### PR TITLE
mouseUp only triggers if mouse.down

### DIFF
--- a/src/atrament.js
+++ b/src/atrament.js
@@ -96,6 +96,10 @@ module.exports = class Atrament extends AtramentEventTarget {
 
       const { mouse } = this;
 
+      if (!mouse.down) {
+        return;
+      }
+
       const position = e.changedTouches && e.changedTouches[0] || e;
       const x = position.offsetX;
       const y = position.offsetY;


### PR DESCRIPTION
Great library!

This fixes a couple undesirable behaviors.

1. Any click outside the canvas results in `strokeend` and `strokerecorded` being called.
2. If you mouseDown outside of the canvas and mouseUp inside the canvas, you get undesirable strokes.

This enforces that a stroke is only started by a click inside the canvas.