### PR TITLE
Added a disabled option to DrawingMode

### DIFF
--- a/src/atrament.js
+++ b/src/atrament.js
@@ -6,7 +6,8 @@ const Pixels = require('./pixels.js');
 const DrawingMode = {
   DRAW: 'draw',
   ERASE: 'erase',
-  FILL: 'fill'
+  FILL: 'fill',
+  DISABLED: 'disabled',
 };
 
 const PathDrawingModes = [DrawingMode.DRAW, DrawingMode.ERASE];
@@ -295,6 +296,9 @@ module.exports = class Atrament extends AtramentEventTarget {
       case DrawingMode.FILL:
         this._mode = DrawingMode.FILL;
         this.context.globalCompositeOperation = 'source-over';
+        break;
+      case DrawingMode.DISABLED:
+        this._mode = DrawingMode.DISABLED;
         break;
       default:
         this._mode = DrawingMode.DRAW;


### PR DESCRIPTION
This just lets the instance set mode to 'disabled'. In that case, no draw/fill/erase should be triggered on mouse move. I wasn't sure if this use case should allow strokes to be created/recorded under disabled mode, so I didn't touch that.