### PR TITLE
added the 'closedPaths' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ sketchpad.smoothing = 1.3;
 sketchpad.adaptiveStroke = false;
 ```
 
+- control whether paths are closed automatically, connecting the end with the start point. `true` by default.
+
+```js
+sketchpad.closedPaths = false;
+```
+
 - record stroke data (enables the `strokerecorded` event). `false` by default.
 
 ```js

--- a/src/atrament.js
+++ b/src/atrament.js
@@ -157,6 +157,7 @@ module.exports = class Atrament extends AtramentEventTarget {
 
     this._mode = DrawingMode.DRAW;
     this.adaptiveStroke = true;
+    this.closedPaths = true;
 
     // update from config object
     ['weight', 'smoothing', 'adaptiveStroke', 'mode']
@@ -186,7 +187,9 @@ module.exports = class Atrament extends AtramentEventTarget {
    * @param {number} y
    */
   endStroke(x, y) {
-    this.context.closePath();
+    if (this.closedPaths) {
+      this.context.closePath();
+    }
 
     if (this.recordStrokes) {
       this.strokeMemory.push(new Point(x, y));


### PR DESCRIPTION
Hi! Thanks for creating this great lib! I'm using it in a little toy project but I didn't want the paths to always be closed automatically when drawing. At first I hacked the behaviour by doing this:

```js
canvas.getContext("2d").closePath = () => {}; // make closePath a no-op
```

But I thought an actual option would be cleaner. So this is my proposal for adding such an option.

Cheers